### PR TITLE
Add optional movie count display to movieList.ts

### DIFF
--- a/client/src/components/movieList.ts
+++ b/client/src/components/movieList.ts
@@ -4,16 +4,28 @@ import { noMoviesInList } from "../components/noMoviesInList";
 
 export default function MovieList(config: MovieListConfig) {
 
-    const { movies, itemConfig, heading, introduction } = config;
+    const { movies, itemConfig, heading, introduction, showCount } = config;
 
     const section = document.createElement("section");
     section.classList.add("page", "container");
 
     if (heading) {
+        const header = document.createElement("div");
+        header.className = "page__header";
+
         const h1 = document.createElement("h1");
         h1.className = "page__title";
         h1.textContent = heading;
-        section.appendChild(h1);
+        header.appendChild(h1);
+
+        if (showCount) {
+            const count = document.createElement("span");
+            count.className = "page__movie-count";
+            count.textContent = `${movies.length} movies in list`;
+            header.appendChild(count);
+        }
+
+        section.appendChild(header);
     }
 
     if (introduction) {

--- a/client/src/pages/browse/index.ts
+++ b/client/src/pages/browse/index.ts
@@ -21,6 +21,7 @@ export default function browse() {
     const browsePageMovieList = MovieList({
         heading: "Popular",
         introduction: "This movies are popular right now.",
+        showCount: false,
         movies,
         itemConfig: {
             showButtons: {

--- a/client/src/pages/watched/index.ts
+++ b/client/src/pages/watched/index.ts
@@ -13,6 +13,7 @@ export default () => {
     const watchlistPageMovieList = MovieList({
         movies,
         heading: "Watched",
+        showCount: true,
         introduction: "This page shows a all movies added to the watched list.",
         itemConfig: {
             showButtons: {

--- a/client/src/pages/watchlist/index.ts
+++ b/client/src/pages/watchlist/index.ts
@@ -14,6 +14,7 @@ export default () => {
         movies,
         heading: "Watchlist",
         introduction: "This page shows a all movies added to the watchlist.",
+        showCount: true,
         itemConfig: {
             showButtons: {
                 watched: true,

--- a/client/src/style.css
+++ b/client/src/style.css
@@ -247,6 +247,14 @@ h6 {
     margin-block: 1.5rem;
 }
 
+.page__header {
+    display: flex;
+    flex-flow: row wrap;
+    gap: 1.5rem;
+    justify-content: space-between;
+    align-items: baseline;
+}
+
 .page__title {
     font-size: 2rem;
     font-weight: 700;

--- a/client/src/types/movie.ts
+++ b/client/src/types/movie.ts
@@ -38,4 +38,5 @@ export type MovieListConfig = {
     itemConfig: Omit<MovieItemConfig, "movie">;
     heading?: string;
     introduction?: string;
+    showCount?: boolean;
 };


### PR DESCRIPTION
Added an optional movie counter to movieList.ts. Now each page that uses movieList.ts can choose to show or not show the amount of movies in a list.

- Added "showCount?: boolean;" to "MovieListConfig" (in movie.ts)
- Added showCount to each page's config
- Created a wrapper div to style heading + counter
- Added some styling

Files modified:

- movieList.ts
- browse/index.ts
- watched/index.ts
- watchlist/index.ts
- style.css
- movie.ts