### PR TITLE
fix: add main as container on every page

### DIFF
--- a/client/src/pages/browse/index.ts
+++ b/client/src/pages/browse/index.ts
@@ -6,7 +6,7 @@ import { getMovies, getSearchInputValue } from "../../lib/store";
 
 export default function browse() {
     const browse = document.createDocumentFragment();
-    const content = document.createDocumentFragment();
+    const content = document.createElement("main");
 
     const heading = document.createElement("h2");
     // const defaultSearchInputValue = getSearchInputValue();

--- a/client/src/pages/details/index.ts
+++ b/client/src/pages/details/index.ts
@@ -13,7 +13,7 @@ export default async (movie: TMDBMovie) => {
     document.title = "Details";
 
     const details = document.createDocumentFragment();
-    const content = document.createDocumentFragment();
+    const content = document.createElement("main");
 
     if (!movie) {
         throw new Error("Movie not found");

--- a/client/src/pages/watched/index.ts
+++ b/client/src/pages/watched/index.ts
@@ -8,6 +8,7 @@ export default () => {
     document.title = "Watched";
 
     const page = document.createDocumentFragment();
+    const content = document.createElement("main");
 
     const movies = getUserListCached().filter(
         (movie) => movie.status === "watched",
@@ -46,7 +47,8 @@ export default () => {
         },
     });
 
-    page.append(header(), watchedFilter(), watchlistPageMovieList, footer());
+    content.append( watchedFilter(), watchlistPageMovieList);
+    page.append(header(), content, footer());
 
     return page;
 };

--- a/client/src/pages/watchlist/index.ts
+++ b/client/src/pages/watchlist/index.ts
@@ -7,6 +7,7 @@ export default () => {
     document.title = "Watchlist";
 
     const page = document.createDocumentFragment();
+    const content = document.createElement("main");
 
     const movies = getUserListCached().filter((movie) => movie.status === "watchlist");
 
@@ -24,7 +25,8 @@ export default () => {
         }
     });
 
-    page.append(header(), watchlistPageMovieList, footer());
+    content.append(watchlistPageMovieList);
+    page.append(header(), content, footer());
 
     return page;
 };


### PR DESCRIPTION
fixes an issue where if `movieList` empty or showed a singular movie browse looked like shit