### PR TITLE
Fix router bug + remove try/catch from getMovieByIdTMDB

### DIFF
--- a/client/src/lib/utils.ts
+++ b/client/src/lib/utils.ts
@@ -39,6 +39,6 @@ export function showToast(message: string, type?: "success" | "error") {
 
 // "Slumpa fram en film", tar mellan 1 och 1000 för att va säker (och slippa en fetch här), eller?
 
-export function getRandomMovieId(min: number = 1, max: number = 1000): number {
+export function getRandomMovieId(min: number = 1, max: number = 100000): number {
     return Math.floor(Math.random() * (max - min + 1)) + min;
 }

--- a/client/src/router.ts
+++ b/client/src/router.ts
@@ -45,8 +45,12 @@ const router = async (): Promise<HTMLElement | DocumentFragment> => {
             return notFound();
         }
 
-        const movie = await getMovieByIdTMDB(movieId);
-        return details(movie);
+        try {
+            const movie = await getMovieByIdTMDB(movieId);
+            return details(movie);
+        } catch {
+            return notFound();
+        }
     }
 
     switch (path) {

--- a/client/src/services/tmdbApi.ts
+++ b/client/src/services/tmdbApi.ts
@@ -25,20 +25,17 @@ export const getPopularMoviesTMDB = async (): Promise<TMDBMovie[]> => {
     }
 };
 
+// Tar bort try/catch för att felet ska nå routern direkt utan att loggas i konsolen först
+
 export const getMovieByIdTMDB = async (id: number) => {
-    try {
-        const res = await fetch(`http://localhost:3000/api/tmdb/${id}`);
+    const res = await fetch(`http://localhost:3000/api/tmdb/${id}`);
 
-        if (!res.ok) {
-            throw new Error(`Failed to fetch movie by ID: ${res.statusText}`);
-        }
-
-        const data: TMDBMovie = await res.json();
-        return data;
-    } catch (error) {
-        console.error("Error getting movie by ID:", error);
-        throw error;
+    if (!res.ok) {
+        throw new Error(`Failed to fetch movie by ID: ${res.statusText}`);
     }
+
+    const data: TMDBMovie = await res.json();
+    return data;
 };
 
 export const getSearchedMovieTMDB = async (


### PR DESCRIPTION
**Fixed router bug and increased random range**
Fixed a bug in the router so that a 404 from TMDB actually generates a 404 page in our app instead of crashing it (details page). Increased the range from 1000 to 100000 in the random function to get a bigger list of images for the error page movie recommenda
tion.

**Remove try/catch from getMovieByIdTMDB to let router handle errors**
Removed try/catch block from getMovieByIdTMDB function that was logging 404 errors before the router could handle them and show the 404 page.

